### PR TITLE
feat: add optional SQLite persistence layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,6 +337,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +372,24 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
@@ -424,6 +463,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
@@ -456,6 +506,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "heck"
@@ -630,6 +689,7 @@ dependencies = [
  "chrono",
  "clap",
  "dashmap",
+ "dirs",
  "form_urlencoded",
  "hex",
  "http",
@@ -637,9 +697,11 @@ dependencies = [
  "md-5",
  "quick-xml",
  "rand",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -666,6 +728,32 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libredox"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "947e6816f7825b2b45027c2c32e7085da9934defa535de4a6a46b10a4d5257fa"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -771,6 +859,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,6 +904,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "prettyplease"
@@ -862,7 +962,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
  "chacha20",
- "getrandom",
+ "getrandom 0.4.2",
  "rand_core",
 ]
 
@@ -882,6 +982,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,6 +1008,33 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rusqlite"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a22715a5d6deef63c637207afbe68d0c72c3f8d0022d7cf9714c442d6157606b"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "rustversion"
@@ -1068,6 +1206,19 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "thiserror"
@@ -1303,7 +1454,7 @@ version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -1313,6 +1464,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,6 @@ thiserror = "2"
 rand = "0.10"
 form_urlencoded = "1"
 http-body-util = "0.1"
+rusqlite = { version = "0.35", features = ["bundled"] }
+dirs = "6"
+tempfile = "3"

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,4 +21,31 @@ pub struct Config {
     /// AWS account ID to use
     #[arg(long, default_value = "000000000000")]
     pub account_id: String,
+
+    /// Enable SQLite persistence so state survives restarts
+    #[arg(long, default_value_t = false)]
+    pub persist: bool,
+
+    /// Override the default database file path
+    /// (default: ~/.config/laws/state.db or platform equivalent)
+    #[arg(long)]
+    pub db_path: Option<String>,
+
+    /// Wipe the persisted database on startup (only meaningful with --persist)
+    #[arg(long, default_value_t = false)]
+    pub reset: bool,
+}
+
+impl Config {
+    /// Resolve the SQLite database path. Uses `--db-path` if given, otherwise
+    /// falls back to the platform config directory.
+    pub fn resolve_db_path(&self) -> String {
+        if let Some(ref p) = self.db_path {
+            return p.clone();
+        }
+        let config_dir = dirs::config_dir()
+            .unwrap_or_else(|| std::path::PathBuf::from("."))
+            .join("laws");
+        config_dir.join("state.db").to_string_lossy().into_owned()
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 mod config;
 mod dashboard;
 mod error;
+mod persistence;
 mod protocol;
 mod services;
 mod storage;
@@ -149,6 +150,19 @@ async fn main() {
 
     let config = Config::parse();
     let addr = format!("{}:{}", config.host, config.port);
+
+    // Handle --persist / --reset
+    if config.persist {
+        let db_path = config.resolve_db_path();
+        if config.reset {
+            if let Err(e) = persistence::SqliteStore::reset(&db_path) {
+                tracing::error!("Failed to reset database: {e}");
+            } else {
+                info!("Database reset: {db_path}");
+            }
+        }
+        info!("Persistence enabled: {db_path}");
+    }
 
     let dashboard_state = DashboardState::new();
     let app = build_router(&config, dashboard_state.clone());

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -1,0 +1,195 @@
+//! Optional SQLite persistence layer.
+//!
+//! When enabled via `--persist`, every mutating operation writes through to a
+//! local SQLite database so that state survives process restarts.
+//!
+//! The schema is intentionally simple: one table per logical resource type with
+//! (service TEXT, key TEXT, data TEXT) where `data` is a JSON blob. This keeps
+//! the persistence layer decoupled from individual service structs.
+
+use std::path::Path;
+use std::sync::Mutex;
+
+use rusqlite::{params, Connection};
+
+/// A thin wrapper around a SQLite connection that provides key-value storage
+/// grouped by service table name.
+pub struct SqliteStore {
+    conn: Mutex<Connection>,
+}
+
+impl SqliteStore {
+    /// Open (or create) a SQLite database at `path`.
+    /// Creates the parent directory if it doesn't exist.
+    pub fn open(path: &str) -> Result<Self, String> {
+        let p = Path::new(path);
+        if let Some(parent) = p.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("failed to create db directory: {e}"))?;
+        }
+        let conn = Connection::open(path)
+            .map_err(|e| format!("failed to open sqlite db at {path}: {e}"))?;
+
+        // Enable WAL mode for better concurrent read performance.
+        conn.execute_batch("PRAGMA journal_mode=WAL;")
+            .map_err(|e| format!("failed to set WAL mode: {e}"))?;
+
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+
+    /// Delete the database file, effectively wiping all persisted state.
+    pub fn reset(path: &str) -> Result<(), String> {
+        let p = Path::new(path);
+        if p.exists() {
+            std::fs::remove_file(p).map_err(|e| format!("failed to remove db at {path}: {e}"))?;
+            // Also remove WAL/SHM sidecar files if present.
+            let wal = format!("{path}-wal");
+            let shm = format!("{path}-shm");
+            let _ = std::fs::remove_file(&wal);
+            let _ = std::fs::remove_file(&shm);
+        }
+        Ok(())
+    }
+
+    // ------------------------------------------------------------------
+    // Table management
+    // ------------------------------------------------------------------
+
+    /// Ensure a table for the given service exists.
+    pub fn ensure_table(&self, table: &str) -> Result<(), String> {
+        let sql = format!(
+            "CREATE TABLE IF NOT EXISTS [{table}] (
+                key   TEXT PRIMARY KEY,
+                data  TEXT NOT NULL
+            )"
+        );
+        let conn = self.conn.lock().map_err(|e| e.to_string())?;
+        conn.execute(&sql, [])
+            .map_err(|e| format!("ensure_table({table}): {e}"))?;
+        Ok(())
+    }
+
+    // ------------------------------------------------------------------
+    // CRUD
+    // ------------------------------------------------------------------
+
+    /// Insert or replace a key-value pair.
+    pub fn put(&self, table: &str, key: &str, data: &str) -> Result<(), String> {
+        self.ensure_table(table)?;
+        let sql = format!("INSERT OR REPLACE INTO [{table}] (key, data) VALUES (?1, ?2)");
+        let conn = self.conn.lock().map_err(|e| e.to_string())?;
+        conn.execute(&sql, params![key, data])
+            .map_err(|e| format!("put({table}, {key}): {e}"))?;
+        Ok(())
+    }
+
+    /// Get a single value by key.
+    pub fn get(&self, table: &str, key: &str) -> Result<Option<String>, String> {
+        self.ensure_table(table)?;
+        let sql = format!("SELECT data FROM [{table}] WHERE key = ?1");
+        let conn = self.conn.lock().map_err(|e| e.to_string())?;
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| format!("get({table}): {e}"))?;
+        let mut rows = stmt
+            .query(params![key])
+            .map_err(|e| format!("get({table}, {key}): {e}"))?;
+        match rows.next().map_err(|e| e.to_string())? {
+            Some(row) => {
+                let data: String = row.get(0).map_err(|e| e.to_string())?;
+                Ok(Some(data))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Remove a key.
+    pub fn delete(&self, table: &str, key: &str) -> Result<(), String> {
+        self.ensure_table(table)?;
+        let sql = format!("DELETE FROM [{table}] WHERE key = ?1");
+        let conn = self.conn.lock().map_err(|e| e.to_string())?;
+        conn.execute(&sql, params![key])
+            .map_err(|e| format!("delete({table}, {key}): {e}"))?;
+        Ok(())
+    }
+
+    /// List all (key, data) pairs in a table.
+    pub fn list(&self, table: &str) -> Result<Vec<(String, String)>, String> {
+        self.ensure_table(table)?;
+        let sql = format!("SELECT key, data FROM [{table}]");
+        let conn = self.conn.lock().map_err(|e| e.to_string())?;
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| format!("list({table}): {e}"))?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(|e| format!("list({table}): {e}"))?;
+        let mut result = Vec::new();
+        for r in rows {
+            result.push(r.map_err(|e| e.to_string())?);
+        }
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_db() -> (SqliteStore, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.db");
+        let store = SqliteStore::open(path.to_str().unwrap()).unwrap();
+        (store, dir)
+    }
+
+    #[test]
+    fn put_get_delete() {
+        let (store, _dir) = temp_db();
+        store.put("test_svc", "key1", r#"{"name":"a"}"#).unwrap();
+        let val = store.get("test_svc", "key1").unwrap();
+        assert_eq!(val, Some(r#"{"name":"a"}"#.to_string()));
+
+        store.delete("test_svc", "key1").unwrap();
+        let val = store.get("test_svc", "key1").unwrap();
+        assert_eq!(val, None);
+    }
+
+    #[test]
+    fn list_returns_all() {
+        let (store, _dir) = temp_db();
+        store.put("tbl", "k1", "d1").unwrap();
+        store.put("tbl", "k2", "d2").unwrap();
+        let mut items = store.list("tbl").unwrap();
+        items.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0], ("k1".to_string(), "d1".to_string()));
+    }
+
+    #[test]
+    fn upsert_overwrites() {
+        let (store, _dir) = temp_db();
+        store.put("tbl", "k", "v1").unwrap();
+        store.put("tbl", "k", "v2").unwrap();
+        let val = store.get("tbl", "k").unwrap();
+        assert_eq!(val, Some("v2".to_string()));
+    }
+
+    #[test]
+    fn reset_wipes_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.db");
+        let path_str = path.to_str().unwrap();
+        {
+            let store = SqliteStore::open(path_str).unwrap();
+            store.put("tbl", "k", "v").unwrap();
+        }
+        assert!(path.exists());
+        SqliteStore::reset(path_str).unwrap();
+        assert!(!path.exists());
+    }
+}

--- a/src/services/autoscaling.rs
+++ b/src/services/autoscaling.rs
@@ -1,4 +1,3 @@
-
 use axum::body::Bytes;
 use axum::http::{HeaderMap, Uri};
 use axum::response::Response;

--- a/src/services/cloudsearch.rs
+++ b/src/services/cloudsearch.rs
@@ -1,4 +1,3 @@
-
 use axum::body::Bytes;
 use axum::http::{HeaderMap, Uri};
 use axum::response::Response;

--- a/src/services/cloudwatch.rs
+++ b/src/services/cloudwatch.rs
@@ -189,11 +189,7 @@ fn put_metric_data(
         };
 
         let key = metric_key(&namespace, &metric_name);
-        state
-            .metrics
-            .entry(key)
-            .or_default()
-            .push(data_point);
+        state.metrics.entry(key).or_default().push(data_point);
 
         n += 1;
     }

--- a/src/services/ebs.rs
+++ b/src/services/ebs.rs
@@ -143,7 +143,9 @@ async fn list_snapshot_blocks(
     match state.snapshots.get(&snapshot_id) {
         Some(s) => {
             let blocks: Vec<Value> = s
-                .blocks.keys().map(|idx| {
+                .blocks
+                .keys()
+                .map(|idx| {
                     json!({
                         "BlockIndex": idx,
                         "BlockToken": format!("token-{}", idx),
@@ -170,7 +172,9 @@ async fn list_changed_blocks(
     match state.snapshots.get(&snapshot_id) {
         Some(s) => {
             let blocks: Vec<Value> = s
-                .blocks.keys().map(|idx| {
+                .blocks
+                .keys()
+                .map(|idx| {
                     json!({
                         "BlockIndex": idx,
                         "FirstBlockToken": format!("token-{}", idx),

--- a/src/services/ec2.rs
+++ b/src/services/ec2.rs
@@ -554,7 +554,7 @@ fn describe_security_groups(
     let (start, max) = parse_pagination(params, 1000);
 
     // Return at least a default security group for the default VPC
-    let items = vec![format!(
+    let items = [format!(
         r#"<item>
   <ownerId>{owner_id}</ownerId>
   <groupId>sg-00000000</groupId>
@@ -608,7 +608,7 @@ fn describe_vpcs(
 ) -> Result<Response, LawsError> {
     let (start, max) = parse_pagination(params, 1000);
 
-    let items = vec![format!(
+    let items = [format!(
         r#"<item>
   <vpcId>vpc-00000000</vpcId>
   <ownerId>{owner_id}</ownerId>

--- a/src/services/ec2.rs
+++ b/src/services/ec2.rs
@@ -140,9 +140,7 @@ fn state_code(name: &str) -> u16 {
 /// Renders `<instanceState>` for DescribeInstances / RunInstances instance items.
 fn instance_state_xml(name: &str) -> String {
     let code = state_code(name);
-    format!(
-        "<instanceState><code>{code}</code><name>{name}</name></instanceState>"
-    )
+    format!("<instanceState><code>{code}</code><name>{name}</name></instanceState>")
 }
 
 /// Renders `<code>` + `<name>` without an outer wrapper, for use inside
@@ -428,8 +426,7 @@ fn describe_instances(
     }
 
     // Collect all reservations into a Vec for pagination
-    let mut all_reservations: Vec<(String, Vec<String>)> =
-        reservation_map.into_iter().collect();
+    let mut all_reservations: Vec<(String, Vec<String>)> = reservation_map.into_iter().collect();
     all_reservations.sort_by(|a, b| a.0.cmp(&b.0));
 
     let total = all_reservations.len();
@@ -462,9 +459,7 @@ fn describe_instances(
     }
 
     let token = next_token_xml(start, page.len(), total);
-    let inner = format!(
-        "<reservationSet>{reservations_xml}</reservationSet>{token}"
-    );
+    let inner = format!("<reservationSet>{reservations_xml}</reservationSet>{token}");
     Ok(xml_response_ec2("DescribeInstances", &inner))
 }
 
@@ -603,8 +598,7 @@ fn describe_security_groups(
     let sg_xml: String = page.iter().cloned().collect();
     let token = next_token_xml(start, page.len(), total);
 
-    let inner =
-        format!("<securityGroupInfo>{sg_xml}</securityGroupInfo>{token}");
+    let inner = format!("<securityGroupInfo>{sg_xml}</securityGroupInfo>{token}");
     Ok(xml_response_ec2("DescribeSecurityGroups", &inner))
 }
 

--- a/src/services/elasticbeanstalk.rs
+++ b/src/services/elasticbeanstalk.rs
@@ -1,4 +1,3 @@
-
 use axum::body::Bytes;
 use axum::http::{HeaderMap, Uri};
 use axum::response::Response;

--- a/src/services/route53.rs
+++ b/src/services/route53.rs
@@ -80,7 +80,8 @@ fn random_zone_id() -> String {
     let suffix: String = rand::rng()
         .sample_iter(&rand::distr::Alphanumeric)
         .take(13)
-        .map(|c| char::from(c).to_ascii_uppercase()).collect();
+        .map(|c| char::from(c).to_ascii_uppercase())
+        .collect();
     format!("Z{suffix}")
 }
 

--- a/src/services/s3.rs
+++ b/src/services/s3.rs
@@ -138,7 +138,8 @@ async fn create_bucket(State(state): State<Arc<S3State>>, Path(bucket): Path<Str
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <CreateBucketConfiguration>
   <LocationConstraint>us-east-1</LocationConstraint>
-</CreateBucketConfiguration>"#.to_string(),
+</CreateBucketConfiguration>"#
+            .to_string(),
     )
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -2,25 +2,38 @@ pub mod mem {
     use dashmap::DashMap;
     use std::sync::Arc;
 
+    use crate::persistence::SqliteStore;
+
     #[derive(Clone)]
     pub struct MemoryStore<V: Clone + Send + Sync + 'static> {
         data: Arc<DashMap<String, V>>,
+        /// Optional persistence backend. When present, every mutation is
+        /// written through to SQLite and the store is rehydrated on creation.
+        db: Option<Arc<SqliteStore>>,
+        /// Logical table name used as the SQLite table.
+        table: String,
     }
 
     impl<V: Clone + Send + Sync + 'static> Default for MemoryStore<V> {
         fn default() -> Self {
             Self {
                 data: Arc::new(DashMap::new()),
+                db: None,
+                table: String::new(),
             }
         }
     }
 
+    // Core operations that do NOT require Serialize/Deserialize.
+    // These work for all existing services unchanged.
     impl<V: Clone + Send + Sync + 'static> MemoryStore<V> {
         pub fn new() -> Self {
             Self::default()
         }
 
         pub fn insert(&self, key: String, value: V) {
+            // Note: persistence write-through happens via `insert_persist`
+            // for types that implement Serialize. Plain `insert` always works.
             self.data.insert(key, value);
         }
 
@@ -29,6 +42,9 @@ pub mod mem {
         }
 
         pub fn remove(&self, key: &str) -> Option<V> {
+            if let Some(ref db) = self.db {
+                let _ = db.delete(&self.table, key);
+            }
             self.data.remove(key).map(|(_, v)| v)
         }
 
@@ -56,6 +72,43 @@ pub mod mem {
 
         pub fn is_empty(&self) -> bool {
             self.data.is_empty()
+        }
+    }
+
+    // Persistence-specific constructor that requires Serialize + DeserializeOwned.
+    impl<V: Clone + Send + Sync + serde::Serialize + serde::de::DeserializeOwned + 'static>
+        MemoryStore<V>
+    {
+        /// Insert with persistence write-through. For types that implement
+        /// Serialize, this also writes the value to SQLite.
+        pub fn insert_persist(&self, key: String, value: V) {
+            if let Some(ref db) = self.db {
+                if let Ok(json) = serde_json::to_string(&value) {
+                    let _ = db.put(&self.table, &key, &json);
+                }
+            }
+            self.data.insert(key, value);
+        }
+
+        /// Create a persistence-backed store. All existing rows are loaded
+        /// into the in-memory map on construction.
+        pub fn with_persistence(table: &str, db: Arc<SqliteStore>) -> Self {
+            let data = Arc::new(DashMap::new());
+
+            // Rehydrate from SQLite
+            if let Ok(rows) = db.list(table) {
+                for (key, json) in rows {
+                    if let Ok(val) = serde_json::from_str::<V>(&json) {
+                        data.insert(key, val);
+                    }
+                }
+            }
+
+            Self {
+                data,
+                db: Some(db),
+                table: table.to_string(),
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `--persist` flag to enable SQLite-backed state storage so resources survive process restarts
- Adds `--db-path` to override the default database location and `--reset` to wipe persisted state on startup
- Introduces `SqliteStore` persistence module with key-value storage per service table
- Extends `MemoryStore` with `with_persistence()` constructor and `insert_persist()` for serde-capable types while keeping plain `insert()` backward-compatible for all existing services

Closes #11