### PR TITLE
feat: show service resources in dashboard

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -136,6 +136,9 @@ struct DispatchState {
     swf: Arc<services::swf::SwfState>,
     verifiedpermissions: Arc<services::verifiedpermissions::VerifiedPermissionsState>,
     workmail: Arc<services::workmail::WorkMailState>,
+    // REST-based services shared for the dashboard resources API
+    s3: Arc<services::s3::S3State>,
+    lambda: Arc<services::lambda::LambdaState>,
 }
 
 #[tokio::main]
@@ -164,9 +167,10 @@ async fn main() {
 
 fn build_router(_config: &Config, dashboard_state: DashboardState) -> Router {
     // ── REST-based services (original) ──
-    let s3_router = services::s3::router(Arc::new(services::s3::S3State::new()));
-    let lambda_router =
-        services::lambda::router(Arc::new(services::lambda::LambdaState::default()));
+    let s3_state = Arc::new(services::s3::S3State::new());
+    let lambda_state = Arc::new(services::lambda::LambdaState::default());
+    let s3_router = services::s3::router(s3_state.clone());
+    let lambda_router = services::lambda::router(lambda_state.clone());
     let apigateway_router =
         services::apigateway::router(Arc::new(services::apigateway::ApiGatewayState::default()));
     let route53_router =
@@ -437,10 +441,16 @@ fn build_router(_config: &Config, dashboard_state: DashboardState) -> Router {
             services::verifiedpermissions::VerifiedPermissionsState::default(),
         ),
         workmail: Arc::new(services::workmail::WorkMailState::default()),
+        s3: s3_state,
+        lambda: lambda_state,
     };
 
     let dispatch_router: Router<()> = Router::<DispatchState>::new()
         .route("/", axum::routing::post(dispatch_handler))
+        .route(
+            "/api/dashboard/resources/{service}",
+            axum::routing::get(resources_handler),
+        )
         .fallback(dispatch_handler)
         .with_state(dispatch_state);
 
@@ -1054,4 +1064,114 @@ fn extract_action(body: &[u8], uri: &axum::http::Uri) -> Option<String> {
         }
     }
     None
+}
+
+// ---------------------------------------------------------------------------
+// Dashboard resources API
+// ---------------------------------------------------------------------------
+
+async fn resources_handler(
+    State(ds): State<DispatchState>,
+    axum::extract::Path(service): axum::extract::Path<String>,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+    use serde_json::json;
+
+    let resources: serde_json::Value = match service.to_lowercase().as_str() {
+        "ec2" => {
+            let instances: Vec<serde_json::Value> = ds
+                .ec2
+                .instances
+                .iter()
+                .map(|entry| {
+                    let i = entry.value();
+                    json!({
+                        "instanceId": i.instance_id,
+                        "state": i.state,
+                        "instanceType": i.instance_type,
+                        "imageId": i.image_id,
+                        "launchTime": i.launch_time,
+                        "vpcId": i.vpc_id,
+                        "subnetId": i.subnet_id,
+                        "privateIpAddress": i.private_ip_address,
+                    })
+                })
+                .collect();
+            json!({ "service": "EC2", "resourceType": "Instances", "resources": instances })
+        }
+        "s3" => {
+            let buckets: Vec<serde_json::Value> = ds
+                .s3
+                .buckets
+                .list()
+                .iter()
+                .map(|(_key, b)| {
+                    json!({
+                        "name": b.name,
+                        "creationDate": b.creation_date,
+                    })
+                })
+                .collect();
+            json!({ "service": "S3", "resourceType": "Buckets", "resources": buckets })
+        }
+        "sqs" => {
+            let queues: Vec<serde_json::Value> = ds
+                .sqs
+                .queues
+                .iter()
+                .map(|entry| {
+                    let q = entry.value();
+                    json!({
+                        "queueName": q.name,
+                        "queueUrl": q.url,
+                        "messageCount": q.messages.len(),
+                    })
+                })
+                .collect();
+            json!({ "service": "SQS", "resourceType": "Queues", "resources": queues })
+        }
+        "dynamodb" => {
+            let tables: Vec<serde_json::Value> = ds
+                .dynamodb
+                .tables
+                .iter()
+                .map(|entry| {
+                    let t = entry.value();
+                    json!({
+                        "tableName": t.table_name,
+                        "status": t.status,
+                        "itemCount": t.items.len(),
+                    })
+                })
+                .collect();
+            json!({ "service": "DynamoDB", "resourceType": "Tables", "resources": tables })
+        }
+        "lambda" => {
+            let functions: Vec<serde_json::Value> = ds
+                .lambda
+                .functions
+                .list()
+                .iter()
+                .map(|(_key, f)| {
+                    json!({
+                        "functionName": f.function_name,
+                        "runtime": f.runtime,
+                        "handler": f.handler,
+                        "lastModified": f.last_modified,
+                    })
+                })
+                .collect();
+            json!({ "service": "Lambda", "resourceType": "Functions", "resources": functions })
+        }
+        _ => {
+            json!({ "service": service, "resourceType": "Unknown", "resources": [] })
+        }
+    };
+
+    (
+        axum::http::StatusCode::OK,
+        [("content-type", "application/json")],
+        serde_json::to_string(&resources).unwrap_or_default(),
+    )
+        .into_response()
 }

--- a/src/services/autoscaling.rs
+++ b/src/services/autoscaling.rs
@@ -1,4 +1,3 @@
-
 use axum::body::Bytes;
 use axum::http::{HeaderMap, Uri};
 use axum::response::Response;

--- a/src/services/cloudsearch.rs
+++ b/src/services/cloudsearch.rs
@@ -1,4 +1,3 @@
-
 use axum::body::Bytes;
 use axum::http::{HeaderMap, Uri};
 use axum::response::Response;

--- a/src/services/cloudwatch.rs
+++ b/src/services/cloudwatch.rs
@@ -189,11 +189,7 @@ fn put_metric_data(
         };
 
         let key = metric_key(&namespace, &metric_name);
-        state
-            .metrics
-            .entry(key)
-            .or_default()
-            .push(data_point);
+        state.metrics.entry(key).or_default().push(data_point);
 
         n += 1;
     }

--- a/src/services/ebs.rs
+++ b/src/services/ebs.rs
@@ -143,7 +143,9 @@ async fn list_snapshot_blocks(
     match state.snapshots.get(&snapshot_id) {
         Some(s) => {
             let blocks: Vec<Value> = s
-                .blocks.keys().map(|idx| {
+                .blocks
+                .keys()
+                .map(|idx| {
                     json!({
                         "BlockIndex": idx,
                         "BlockToken": format!("token-{}", idx),
@@ -170,7 +172,9 @@ async fn list_changed_blocks(
     match state.snapshots.get(&snapshot_id) {
         Some(s) => {
             let blocks: Vec<Value> = s
-                .blocks.keys().map(|idx| {
+                .blocks
+                .keys()
+                .map(|idx| {
                     json!({
                         "BlockIndex": idx,
                         "FirstBlockToken": format!("token-{}", idx),

--- a/src/services/ec2.rs
+++ b/src/services/ec2.rs
@@ -554,7 +554,7 @@ fn describe_security_groups(
     let (start, max) = parse_pagination(params, 1000);
 
     // Return at least a default security group for the default VPC
-    let items = vec![format!(
+    let items = [format!(
         r#"<item>
   <ownerId>{owner_id}</ownerId>
   <groupId>sg-00000000</groupId>
@@ -608,7 +608,7 @@ fn describe_vpcs(
 ) -> Result<Response, LawsError> {
     let (start, max) = parse_pagination(params, 1000);
 
-    let items = vec![format!(
+    let items = [format!(
         r#"<item>
   <vpcId>vpc-00000000</vpcId>
   <ownerId>{owner_id}</ownerId>

--- a/src/services/ec2.rs
+++ b/src/services/ec2.rs
@@ -140,9 +140,7 @@ fn state_code(name: &str) -> u16 {
 /// Renders `<instanceState>` for DescribeInstances / RunInstances instance items.
 fn instance_state_xml(name: &str) -> String {
     let code = state_code(name);
-    format!(
-        "<instanceState><code>{code}</code><name>{name}</name></instanceState>"
-    )
+    format!("<instanceState><code>{code}</code><name>{name}</name></instanceState>")
 }
 
 /// Renders `<code>` + `<name>` without an outer wrapper, for use inside
@@ -428,8 +426,7 @@ fn describe_instances(
     }
 
     // Collect all reservations into a Vec for pagination
-    let mut all_reservations: Vec<(String, Vec<String>)> =
-        reservation_map.into_iter().collect();
+    let mut all_reservations: Vec<(String, Vec<String>)> = reservation_map.into_iter().collect();
     all_reservations.sort_by(|a, b| a.0.cmp(&b.0));
 
     let total = all_reservations.len();
@@ -462,9 +459,7 @@ fn describe_instances(
     }
 
     let token = next_token_xml(start, page.len(), total);
-    let inner = format!(
-        "<reservationSet>{reservations_xml}</reservationSet>{token}"
-    );
+    let inner = format!("<reservationSet>{reservations_xml}</reservationSet>{token}");
     Ok(xml_response_ec2("DescribeInstances", &inner))
 }
 
@@ -603,8 +598,7 @@ fn describe_security_groups(
     let sg_xml: String = page.iter().cloned().collect();
     let token = next_token_xml(start, page.len(), total);
 
-    let inner =
-        format!("<securityGroupInfo>{sg_xml}</securityGroupInfo>{token}");
+    let inner = format!("<securityGroupInfo>{sg_xml}</securityGroupInfo>{token}");
     Ok(xml_response_ec2("DescribeSecurityGroups", &inner))
 }
 

--- a/src/services/elasticbeanstalk.rs
+++ b/src/services/elasticbeanstalk.rs
@@ -1,4 +1,3 @@
-
 use axum::body::Bytes;
 use axum::http::{HeaderMap, Uri};
 use axum::response::Response;

--- a/src/services/route53.rs
+++ b/src/services/route53.rs
@@ -80,7 +80,8 @@ fn random_zone_id() -> String {
     let suffix: String = rand::rng()
         .sample_iter(&rand::distr::Alphanumeric)
         .take(13)
-        .map(|c| char::from(c).to_ascii_uppercase()).collect();
+        .map(|c| char::from(c).to_ascii_uppercase())
+        .collect();
     format!("Z{suffix}")
 }
 

--- a/src/services/s3.rs
+++ b/src/services/s3.rs
@@ -138,7 +138,8 @@ async fn create_bucket(State(state): State<Arc<S3State>>, Path(bucket): Path<Str
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <CreateBucketConfiguration>
   <LocationConstraint>us-east-1</LocationConstraint>
-</CreateBucketConfiguration>"#.to_string(),
+</CreateBucketConfiguration>"#
+            .to_string(),
     )
 }
 

--- a/ui/src/components/ResourcePanel.vue
+++ b/ui/src/components/ResourcePanel.vue
@@ -1,0 +1,135 @@
+<script setup lang="ts">
+import { ref, watch, onUnmounted } from 'vue'
+import { Database, RefreshCw, Inbox } from 'lucide-vue-next'
+import AppCard from './ui/AppCard.vue'
+
+const props = defineProps<{
+  serviceId: string
+}>()
+
+interface ResourceResponse {
+  service: string
+  resourceType: string
+  resources: Record<string, unknown>[]
+}
+
+const data = ref<ResourceResponse | null>(null)
+const loading = ref(false)
+const error = ref<string | null>(null)
+let pollTimer: ReturnType<typeof setInterval> | null = null
+
+async function fetchResources() {
+  loading.value = true
+  error.value = null
+  try {
+    const resp = await fetch(`/api/dashboard/resources/${props.serviceId}`)
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+    data.value = await resp.json()
+  } catch (e: unknown) {
+    error.value = (e as Error).message
+  } finally {
+    loading.value = false
+  }
+}
+
+function startPolling() {
+  stopPolling()
+  fetchResources()
+  pollTimer = setInterval(fetchResources, 5000)
+}
+
+function stopPolling() {
+  if (pollTimer) {
+    clearInterval(pollTimer)
+    pollTimer = null
+  }
+}
+
+watch(
+  () => props.serviceId,
+  () => startPolling(),
+  { immediate: true },
+)
+
+onUnmounted(() => stopPolling())
+
+function columnHeaders(resources: Record<string, unknown>[]): string[] {
+  if (resources.length === 0) return []
+  return Object.keys(resources[0])
+}
+
+function formatHeader(key: string): string {
+  return key.replace(/([A-Z])/g, ' $1').replace(/^./, (s) => s.toUpperCase())
+}
+</script>
+
+<template>
+  <AppCard>
+    <template #header>
+      <Database class="h-4 w-4" />
+      Resources
+      <span v-if="data" class="text-muted-foreground font-normal ml-1">
+        ({{ data.resources.length }} {{ data.resourceType }})
+      </span>
+      <button
+        @click="fetchResources"
+        class="ml-auto p-1 rounded hover:bg-accent/50 transition-colors text-muted-foreground hover:text-foreground"
+        title="Refresh"
+      >
+        <RefreshCw class="h-3.5 w-3.5" :class="{ 'animate-spin': loading }" />
+      </button>
+    </template>
+
+    <!-- Loading -->
+    <div v-if="loading && !data" class="flex items-center justify-center h-24 text-sm text-muted-foreground">
+      Loading resources...
+    </div>
+
+    <!-- Error -->
+    <div v-else-if="error" class="flex items-center justify-center h-24 text-sm text-destructive">
+      Failed to load: {{ error }}
+    </div>
+
+    <!-- Empty -->
+    <div
+      v-else-if="data && data.resources.length === 0"
+      class="flex flex-col items-center justify-center h-24 gap-2 text-sm text-muted-foreground"
+    >
+      <Inbox class="h-6 w-6" />
+      No resources found
+    </div>
+
+    <!-- Table -->
+    <div v-else-if="data && data.resources.length > 0" class="overflow-x-auto">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-b border-border">
+            <th
+              v-for="col in columnHeaders(data.resources)"
+              :key="col"
+              class="text-left p-2 text-xs font-medium text-muted-foreground uppercase tracking-wider"
+            >
+              {{ formatHeader(col) }}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="(resource, idx) in data.resources"
+            :key="idx"
+            class="border-b border-border/50 hover:bg-accent/30 transition-colors"
+          >
+            <td
+              v-for="col in columnHeaders(data.resources)"
+              :key="col"
+              class="p-2 font-mono text-xs"
+            >
+              {{ resource[col] ?? '—' }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </AppCard>
+</template>
+</script>

--- a/ui/src/components/ResourcePanel.vue
+++ b/ui/src/components/ResourcePanel.vue
@@ -132,4 +132,3 @@ function formatHeader(key: string): string {
     </div>
   </AppCard>
 </template>
-</script>

--- a/ui/src/components/ServiceDetail.vue
+++ b/ui/src/components/ServiceDetail.vue
@@ -8,6 +8,7 @@ import { usePinnedServices } from '../composables/usePinnedServices'
 import AppBadge from './ui/AppBadge.vue'
 import AppCard from './ui/AppCard.vue'
 import RequestTable from './RequestTable.vue'
+import ResourcePanel from './ResourcePanel.vue'
 
 const route = useRoute()
 const { events } = useSSE()
@@ -103,6 +104,9 @@ const stats = computed(() => {
         <p class="text-2xl font-bold tabular-nums text-destructive">{{ stats.errors }}</p>
       </AppCard>
     </div>
+
+    <!-- Resources -->
+    <ResourcePanel :serviceId="serviceId" />
 
     <!-- Actions seen -->
     <div v-if="stats.actions.length > 0">


### PR DESCRIPTION
## Summary
- Adds `GET /api/dashboard/resources/:service` REST endpoint that returns JSON with current resources for EC2 (instances), S3 (buckets), SQS (queues), DynamoDB (tables), and Lambda (functions)
- New `ResourcePanel.vue` component with auto-refresh polling (5s interval), dynamic column rendering, and loading/empty/error states
- Integrated into the existing `ServiceDetail.vue` page between the stats cards and the request log, so clicking a service now shows both live resources and API logs

Closes #12