### PR TITLE
Embed dashboard UI.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +198,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -294,6 +302,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,6 +372,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "display_full_error"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7c47e9a2fd28a8edd1446f10dabe8ac5d26bb77ed2b1077bfcd8308904e8c6"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +416,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -467,17 +500,35 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core",
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
@@ -675,6 +726,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -706,6 +767,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "static-serve",
  "tempfile",
  "thiserror",
  "tokio",
@@ -820,6 +882,16 @@ checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -956,6 +1028,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -976,6 +1054,18 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "range-requests"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a80a58719403473ceb7fed3cf4dc84ca007dbeec7a7b686151c6f82a18a4f9ac"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "http",
+ "thiserror",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1179,6 +1269,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,6 +1306,36 @@ dependencies = [
  "js-sys",
  "rsqlite-vfs",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "static-serve"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f57f0b71026b8bf12d7d66e819f2258b209a4b14a1acdeed4602b48d1d97b35"
+dependencies = [
+ "axum",
+ "bytes",
+ "range-requests",
+ "static-serve-macro",
+]
+
+[[package]]
+name = "static-serve-macro"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c4f9078e7a4de554122a49d6e0ff5a183192b471f6d4abfbd6e3755bf4d5d2a"
+dependencies = [
+ "display_full_error",
+ "flate2",
+ "glob",
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "sha2",
+ "syn",
+ "thiserror",
+ "zstd",
 ]
 
 [[package]]
@@ -1763,3 +1889,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ http-body-util = "0.1"
 rusqlite = { version = "0.39", features = ["bundled"] }
 dirs = "6"
 tempfile = "3"
+static-serve = "0.6.1"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,23 @@
+fn main() {
+    // Don't want just ui, as then the build output would invalidate
+    // it every run. This isn't complete, but it's probably fine for dev.
+    println!("cargo-rebuild-if-changed=ui/index.html");
+    println!("cargo-rebuild-if-changed=ui/src");
+    println!("cargo-rebuild-if-changed=ui/package-lock.json");
+
+    let status = std::process::Command::new("npm")
+        .arg("ci")
+        .arg("--ignore-scripts")
+        .current_dir("ui")
+        .status()
+        .unwrap();
+    assert!(status.success(), "npm ci failed: {}", status);
+
+    let status = std::process::Command::new("npm")
+        .arg("run")
+        .arg("build")
+        .current_dir("ui")
+        .status()
+        .unwrap();
+    assert!(status.success(), "npm run build failed: {}", status);
+}

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,9 @@
 fn main() {
     // Don't want just ui, as then the build output would invalidate
     // it every run. This isn't complete, but it's probably fine for dev.
-    println!("cargo-rebuild-if-changed=ui/index.html");
-    println!("cargo-rebuild-if-changed=ui/src");
-    println!("cargo-rebuild-if-changed=ui/package-lock.json");
+    println!("cargo:rerun-if-changed=ui/index.html");
+    println!("cargo:rerun-if-changed=ui/src");
+    println!("cargo:rerun-if-changed=ui/package-lock.json");
 
     let status = std::process::Command::new("npm")
         .arg("ci")

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,6 @@ use axum::extract::State;
 use axum::Router;
 use clap::Parser;
 use tower_http::cors::CorsLayer;
-use tower_http::services::{ServeDir, ServeFile};
 use tower_http::trace::TraceLayer;
 use tracing::info;
 
@@ -567,9 +566,16 @@ fn build_router(
         .merge(workdocs_router)
         // Dashboard
         .merge(dashboard::router(dashboard_state.clone()))
-        .route_service("/dashboard", ServeFile::new("ui/dist/index.html"))
-        .route_service("/dashboard/", ServeFile::new("ui/dist/index.html"))
-        .nest_service("/dashboard/assets", ServeDir::new("ui/dist/assets"))
+        .nest("/dashboard", {
+            static_serve::embed_assets!(
+                "ui/dist",
+                strip_html_ext = true, // don't require explicit "index.html"
+                cache_busted_paths = ["assets"]
+            );
+            static_router()
+                // Don't use below fallbacks
+                .fallback(|| async { (http::StatusCode::NOT_FOUND, "Dashboard asset not found") })
+        })
         // Dispatch fallback + S3 catch-all
         .merge(dispatch_router)
         .merge(s3_router)


### PR DESCRIPTION

## Related Issue

Closes #28

## Description

Uses the `serve_static` approach I described in the issue, since I'm lazy:

- Uses `build.rs` to build the UI automatically, which should make `cargo install` work (I guess we'll find out?)
- Replace the `tower_http` middleware with the `serve_static` router.
- Also tack on a not found fallback route so e.g. `/dashboard/whatever` doesn't try to load `s3:://dashboard/whatever` which I feel would be confusing.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked this PR to an existing issue
- [x] My code follows the project's code style
- [x] I have tested my changes locally
- [ ] I have added/updated relevant documentation (if applicable)
- [x] My changes don't introduce new warnings

## Additional Notes

This (unsurprisingly) means building the binary now requires the ability to do the UI build, e.g. have a node install. This is true for Github Actions runners, so that *should* be fine, but I suppose it would be reasonable to be able to disable the dashboard by making it a default feature to unblock people that don't need it?

If that's desired I could take a look at doing so in a separate PR.
