### PR TITLE
feat: embed dashboard UI into the binary

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,10 +26,8 @@ Thank you for your interest in contributing to laws! This document provides guid
 git clone https://github.com/YOUR_USERNAME/laws.git
 cd laws
 
-# Build the UI
-cd ui && npm install && npm run build && cd ..
-
-# Build the project
+# Build the project (build.rs compiles the dashboard UI in ui/ and embeds it
+# into the binary; requires Node.js/npm. Set LAWS_SKIP_UI_BUILD=1 to skip it.)
 cargo build
 
 # Run in development mode
@@ -138,7 +136,7 @@ aws --endpoint-url http://localhost:4566 myservice list-items
 cargo clippy -- -D warnings
 cargo fmt --check
 
-# Build UI
+# Type-check the UI on its own (cargo build already runs the UI build)
 cd ui && npm run build
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,7 +155,7 @@ checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -192,6 +198,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -257,7 +265,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -291,6 +299,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -355,6 +372,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "display_full_error"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7c47e9a2fd28a8edd1446f10dabe8ac5d26bb77ed2b1077bfcd8308904e8c6"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +416,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -480,6 +513,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,12 +595,6 @@ dependencies = [
  "http-body",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "http-range-header"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
 
 [[package]]
 name = "httparse"
@@ -675,6 +708,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.2",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -706,6 +749,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "static-serve",
  "tempfile",
  "thiserror",
  "tokio",
@@ -823,6 +867,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,7 +977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -976,6 +1030,18 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "range-requests"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e30cea6780132baa8257e81ab3f6e11526a9271e9032963eab8d830972e68b6"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "http",
+ "thiserror",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1103,7 +1169,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1179,6 +1245,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,6 +1285,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "static-serve"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49c7a4b3dbe44375f7e30895c04d3ca4fde020eb7336c0f6a71ed495c5302e1a"
+dependencies = [
+ "axum",
+ "bytes",
+ "range-requests",
+ "static-serve-macro",
+]
+
+[[package]]
+name = "static-serve-macro"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cb887d817cf39e80fd7fdd21c4f138c8277d7dc2623fee4d07e141f4ce32a0a"
+dependencies = [
+ "display_full_error",
+ "flate2",
+ "glob",
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "sha2",
+ "syn 3.0.4",
+ "thiserror",
+ "zstd",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,6 +1325,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1265,7 +1378,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1302,7 +1415,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1354,19 +1467,9 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags",
  "bytes",
- "futures-core",
- "futures-util",
  "http",
  "http-body",
- "http-body-util",
- "http-range-header",
- "httpdate",
- "mime",
- "mime_guess",
- "percent-encoding",
  "pin-project-lite",
- "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1404,7 +1507,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1555,7 +1658,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -1623,7 +1726,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1634,7 +1737,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1700,7 +1803,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -1716,7 +1819,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -1763,3 +1866,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 clap = { version = "4", features = ["derive"] }
 dashmap = "6"
-tower-http = { version = "0.6", features = ["cors", "trace", "fs"] }
+tower-http = { version = "0.6", features = ["cors", "trace"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 bytes = "1"
 http = "1"
@@ -33,3 +33,4 @@ http-body-util = "0.1"
 rusqlite = { version = "0.39", features = ["bundled"] }
 dirs = "6"
 tempfile = "3"
+static-serve = "0.6"

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,11 +32,16 @@ COPY Cargo.toml Cargo.lock ./
 # Create dummy src to build dependencies
 RUN mkdir src && echo "fn main() {}" > src/main.rs
 
+# The UI is built in the ui-builder stage; skip npm inside cargo's build script
+ENV LAWS_SKIP_UI_BUILD=1
+
 # Build dependencies only
 RUN cargo build --release && rm -rf src
 
-# Copy actual source code
+# Copy actual source code and the prebuilt UI (embedded into the binary by build.rs)
 COPY src ./src
+COPY build.rs ./
+COPY --from=ui-builder /app/ui/dist ./ui/dist
 
 # Build the actual binary
 RUN touch src/main.rs && cargo build --release
@@ -52,11 +57,6 @@ RUN apt-get update && apt-get install -y \
 
 # Copy binary from builder
 COPY --from=builder /app/target/release/laws /usr/local/bin/laws
-
-# Copy UI dist from ui-builder
-COPY --from=ui-builder /app/ui/dist /usr/local/share/laws/ui/dist
-
-WORKDIR /usr/local/share/laws
 
 EXPOSE 4566
 

--- a/README.md
+++ b/README.md
@@ -275,12 +275,16 @@ docker run --rm -p 4566:4566 laws
 
 ### From Source
 
+Requires Rust and Node.js (the dashboard UI is built by `build.rs` and embedded into the binary, so the resulting executable is self-contained).
+
 ```bash
 git clone https://github.com/huseyinbabal/laws.git
 cd laws
 cargo build --release
 ./target/release/laws
 ```
+
+To build without Node.js (no dashboard UI), set `LAWS_SKIP_UI_BUILD=1`.
 
 ## Quick Start
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,49 @@
+//! Builds the dashboard UI (ui/ -> ui/dist) so it can be embedded into the
+//! binary by `static_serve::embed_assets!` in main.rs.
+//!
+//! Set `LAWS_SKIP_UI_BUILD=1` to skip running npm (e.g. in Docker, where the
+//! UI is built in a separate stage and copied into ui/dist beforehand).
+
+use std::path::Path;
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=LAWS_SKIP_UI_BUILD");
+    println!("cargo:rerun-if-changed=ui/index.html");
+    println!("cargo:rerun-if-changed=ui/src");
+    println!("cargo:rerun-if-changed=ui/package-lock.json");
+    println!("cargo:rerun-if-changed=ui/vite.config.ts");
+
+    let dist = Path::new("ui/dist");
+
+    if std::env::var_os("LAWS_SKIP_UI_BUILD").is_some() {
+        if !dist.join("index.html").exists() {
+            // embed_assets! needs the directory to exist; ship a stub so the
+            // binary still builds without a dashboard.
+            std::fs::create_dir_all(dist.join("assets")).expect("create ui/dist/assets");
+            std::fs::write(
+                dist.join("index.html"),
+                "<!doctype html><title>laws</title><p>Dashboard UI was not built (LAWS_SKIP_UI_BUILD was set).</p>",
+            )
+            .expect("write ui/dist/index.html");
+        }
+        return;
+    }
+
+    run("npm", &["ci", "--ignore-scripts"]);
+    run("npm", &["run", "build"]);
+}
+
+fn run(program: &str, args: &[&str]) {
+    let status = Command::new(program).args(args).current_dir("ui").status();
+    match status {
+        Ok(s) if s.success() => {}
+        Ok(s) => panic!("`{program} {}` failed with {s}", args.join(" ")),
+        Err(e) => panic!(
+            "failed to run `{program} {}`: {e}\n\
+             Building laws requires Node.js/npm to compile the dashboard UI.\n\
+             Install Node.js, or set LAWS_SKIP_UI_BUILD=1 to build without the dashboard.",
+            args.join(" ")
+        ),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,10 +12,10 @@ mod storage;
 use std::sync::Arc;
 
 use axum::extract::State;
+use axum::response::IntoResponse;
 use axum::Router;
 use clap::Parser;
 use tower_http::cors::CorsLayer;
-use tower_http::services::{ServeDir, ServeFile};
 use tower_http::trace::TraceLayer;
 use tracing::info;
 
@@ -568,9 +568,10 @@ fn build_router(
         .merge(workdocs_router)
         // Dashboard
         .merge(dashboard::router(dashboard_state.clone()))
-        .route_service("/dashboard", ServeFile::new("ui/dist/index.html"))
-        .route_service("/dashboard/", ServeFile::new("ui/dist/index.html"))
-        .nest_service("/dashboard/assets", ServeDir::new("ui/dist/assets"))
+        // UI assets are compiled into the binary (see build.rs). `nest_service`
+        // (not `nest`) so the 404 fallback below is honoured and unknown
+        // /dashboard/* paths don't fall through to the S3 catch-all.
+        .nest_service("/dashboard", dashboard_ui_router())
         // Dispatch fallback + S3 catch-all
         .merge(dispatch_router)
         .merge(s3_router)
@@ -581,6 +582,26 @@ fn build_router(
         .layer(CorsLayer::permissive())
         .layer(TraceLayer::new_for_http())
 }
+
+fn dashboard_ui_router() -> Router {
+    static_serve::embed_assets!(
+        "ui/dist",
+        strip_html_ext = true,
+        cache_busted_paths = ["assets"]
+    );
+    // SPA fallback: client-side routes like /dashboard/ecr must serve
+    // index.html; only unknown hashed assets are a real 404.
+    static_router().fallback(|uri: axum::http::Uri| async move {
+        if uri.path().starts_with("/assets/") {
+            (http::StatusCode::NOT_FOUND, "Dashboard asset not found").into_response()
+        } else {
+            axum::response::Html(DASHBOARD_INDEX_HTML).into_response()
+        }
+    })
+}
+
+const DASHBOARD_INDEX_HTML: &str =
+    include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/ui/dist/index.html"));
 
 #[axum::debug_handler(state = DispatchState)]
 async fn dispatch_handler(


### PR DESCRIPTION
## Related Issue

Closes #28

## Description

Embeds the dashboard UI into the `laws` binary so it is self-contained — no `ui/dist` directory needed at runtime (fixes the blank dashboard when running the binary from another directory, `cargo install`, etc.).

- `build.rs` runs `npm ci && npm run build` in `ui/` and `static_serve::embed_assets!` compiles `ui/dist` into the binary. `LAWS_SKIP_UI_BUILD=1` skips npm (a stub page is embedded instead) for environments without Node.
- `/dashboard` is mounted with `nest_service` (axum 0.8's `nest` drops the nested router's fallback), with an SPA fallback: client-side routes like `/dashboard/ecr` serve `index.html` on refresh, and only unknown `/dashboard/assets/*` paths return 404 — nothing under `/dashboard` falls through to the S3 catch-all anymore.
- Dockerfile: UI is still built in the `node` stage, then copied into the Rust stage with `LAWS_SKIP_UI_BUILD=1`; the runtime stage no longer ships `ui/dist`.
- Dropped the now-unused `tower-http` `fs` feature; README/CONTRIBUTING updated (Node.js is a build requirement).

Builds on the approach in #29 by @simonbuchan — this PR additionally fixes `/dashboard/` and deep-link refreshes (which 404'd there), the Docker build (Rust stage had no Node), and adds the skip switch.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Testing

- `cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `cargo test` (25 passed)
- Binary run from an unrelated cwd: `/dashboard`, `/dashboard/`, `/dashboard/ecr` → 200 html; hashed JS/CSS → 200; `/dashboard/assets/x.js` → 404; `/api/dashboard/*` and AWS dispatch unaffected
- `LAWS_SKIP_UI_BUILD=1 cargo build` with and without an existing `ui/dist`
- `docker build` + run: dashboard and deep links served from the container

## Checklist

- [x] I have linked this PR to an existing issue
- [x] My code follows the project's code style
- [x] I have tested my changes locally
- [x] I have added/updated relevant documentation (if applicable)
- [x] My changes don't introduce new warnings