### PR TITLE
fix(release): make the dashboard UI build work on Windows and cross/musl

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,16 @@
+# Configuration for `cross` (used by the release workflow for Linux musl targets).
+#
+# build.rs compiles the dashboard UI with npm, but the cross images are Ubuntu
+# 18.04 (glibc 2.27) with no Node.js. Official Node >= 18 needs glibc >= 2.28,
+# so we install the unofficial "glibc-217" build of Node 22 (Vite 8 requires
+# Node >= 22.12). This runs once when cross builds its derived image.
+
+[target.x86_64-unknown-linux-musl]
+pre-build = [
+    "NODE_VERSION=v22.12.0 && curl -fsSL https://unofficial-builds.nodejs.org/download/release/$NODE_VERSION/node-$NODE_VERSION-linux-x64-glibc-217.tar.xz -o /tmp/node.tar.xz && tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1 && rm /tmp/node.tar.xz && node --version && npm --version",
+]
+
+[target.aarch64-unknown-linux-musl]
+pre-build = [
+    "NODE_VERSION=v22.12.0 && curl -fsSL https://unofficial-builds.nodejs.org/download/release/$NODE_VERSION/node-$NODE_VERSION-linux-x64-glibc-217.tar.xz -o /tmp/node.tar.xz && tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1 && rm /tmp/node.tar.xz && node --version && npm --version",
+]

--- a/build.rs
+++ b/build.rs
@@ -30,8 +30,11 @@ fn main() {
         return;
     }
 
-    run("npm", &["ci", "--ignore-scripts"]);
-    run("npm", &["run", "build"]);
+    // On Windows, npm is a batch script (npm.cmd); `Command::new("npm")`
+    // only resolves executables, so it would fail with "program not found".
+    let npm = if cfg!(windows) { "npm.cmd" } else { "npm" };
+    run(npm, &["ci", "--ignore-scripts"]);
+    run(npm, &["run", "build"]);
 }
 
 fn run(program: &str, args: &[&str]) {


### PR DESCRIPTION
## Related Issue

Follow-up to #28 / #43 — fixes the failed `v1.2.0` release run (https://github.com/huseyinbabal/laws/actions/runs/33017034175).

## Description

After #43, `build.rs` compiles the dashboard UI with npm. The release workflow's `build-windows` and `build-linux` jobs then failed with `failed to run npm ci --ignore-scripts: program not found` (macOS jobs passed):

- **Windows**: npm is a batch script (`npm.cmd`); Rust's `Command::new("npm")` only resolves executables. `build.rs` now uses `npm.cmd` on Windows.
- **Linux musl (`cross`)**: the `cross` images are Ubuntu 18.04 with no Node.js, and glibc 2.27 is too old for official Node ≥ 18. Added `Cross.toml` with a `pre-build` step that installs Node 22.12 from Node's unofficial `glibc-217` builds (Vite 8 requires Node ≥ 22.12). This runs once when `cross` builds its derived image; the reusable workflow in `rust-actions` needs no changes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- Verified the install command inside `ghcr.io/cross-rs/aarch64-unknown-linux-musl:0.2.5`: `node --version` → v22.12.0, `npm --version` → 10.9.0.
- Confirmed `target.<TARGET>.pre-build` is supported by cross 0.2.5 (the version the workflow installs).
- `cargo build`, `cargo fmt --check` locally. Couldn't run `cross` end-to-end from an Apple Silicon host (x86-only images), so the Linux jobs get their real test on the next release run.

## After merging

The `v1.2.0` tag points at a commit before this fix and no GitHub release was created for it, so the tag needs to be moved to include this fix and the release re-run:

```bash
git tag -d v1.2.0 && git push origin :refs/tags/v1.2.0
git tag v1.2.0 <merge commit> && git push origin v1.2.0
```

## Checklist

- [x] I have linked this PR to an existing issue
- [x] My code follows the project's code style
- [x] I have tested my changes locally
- [ ] I have added/updated relevant documentation (if applicable)
- [x] My changes don't introduce new warnings